### PR TITLE
[PRODUCT-2001] Add GraphQL info to Language Standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,12 +130,13 @@ then, you MUST move to [First-party](#first-party).
 
 ## Language standards
 
-| Language   | Style                                              | Docstrings                                                        | Testing                                                    | Linting                                                       |
-|------------|----------------------------------------------------|-------------------------------------------------------------------|------------------------------------------------------------|---------------------------------------------------------------|
-| HTML       | [Prettier](https://prettier.io/)                   | N/A                                                               | [HTMLProofer](https://github.com/gjtorikian/html-proofer/) | N/A                                                           |
-| JavaScript | [Prettier](https://prettier.io/)                   | [JSDoc](http://usejsdoc.org/)                                     | [Jest](https://jestjs.io/)                                 | [ESLint](https://eslint.org/)                                 |
-| Markdown   | [Prettier](https://prettier.io/)                   | N/A                                                               | N/A                                                        | [Markdownlint](https://github.com/markdownlint/markdownlint/) |
-| Python     | [PEP 8](https://www.python.org/dev/peps/pep-0008/) | [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) | [pytest](https://pytest.org/)                              | [Pylint](https://www.pylint.org/)                             |
+| Language   | Style                                              | Docstrings                                                        | Testing                                                    | Linting                                                                    |
+|------------|----------------------------------------------------|-------------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------|
+| HTML       | [Prettier](https://prettier.io/)                   | N/A                                                               | [HTMLProofer](https://github.com/gjtorikian/html-proofer/) | N/A                                                                        |
+| JavaScript | [Prettier](https://prettier.io/)                   | [JSDoc](http://usejsdoc.org/)                                     | [Jest](https://jestjs.io/)                                 | [ESLint](https://eslint.org/)                                              |
+| Markdown   | [Prettier](https://prettier.io/)                   | N/A                                                               | N/A                                                        | [Markdownlint](https://github.com/markdownlint/markdownlint/)              |
+| Python     | [PEP 8](https://www.python.org/dev/peps/pep-0008/) | [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) | [pytest](https://pytest.org/)                              | [Pylint](https://www.pylint.org/)                                          |
+| GraphQL    | [GraphQL Rules](https://graphql-rules.com/)        | N/A                                                               | N/A                                                        | [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) |
 
 ## Q-CTRL coding standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,11 +132,11 @@ then, you MUST move to [First-party](#first-party).
 
 | Language   | Style                                              | Docstrings                                                        | Testing                                                    | Linting                                                                    |
 |------------|----------------------------------------------------|-------------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------|
+| GraphQL    | [GraphQL Rules](https://graphql-rules.com/)        | N/A                                                               | N/A                                                        | [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) |
 | HTML       | [Prettier](https://prettier.io/)                   | N/A                                                               | [HTMLProofer](https://github.com/gjtorikian/html-proofer/) | N/A                                                                        |
 | JavaScript | [Prettier](https://prettier.io/)                   | [JSDoc](http://usejsdoc.org/)                                     | [Jest](https://jestjs.io/)                                 | [ESLint](https://eslint.org/)                                              |
 | Markdown   | [Prettier](https://prettier.io/)                   | N/A                                                               | N/A                                                        | [Markdownlint](https://github.com/markdownlint/markdownlint/)              |
 | Python     | [PEP 8](https://www.python.org/dev/peps/pep-0008/) | [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) | [pytest](https://pytest.org/)                              | [Pylint](https://www.pylint.org/)                                          |
-| GraphQL    | [GraphQL Rules](https://graphql-rules.com/)        | N/A                                                               | N/A                                                        | [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) |
 
 ## Q-CTRL coding standards
 


### PR DESCRIPTION
Fixes https://q-ctrl.atlassian.net/browse/PRODUCT-2001 .

Changes proposed in this pull request:

- Add a row for GraphQL to the Language Standards section
