### PR TITLE
Add standard for variables representing counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,7 @@ then, you MUST move to [First-party](#first-party).
 
 - Spell variable names out in full using American English spelling (e.g. `optimized_pulse` or `optimizedPulse` and **NOT** `op`)
 - For variable names that are more than three words, use an acronym (e.g. `cpmg` and **NOT** `carr_purcell_meiboom_gill` or `carrPurcellMeiboomGill`)
+- For variable names that describe how many of an object there are, use `<object>_count` (not `<object>s_count`, not `number_of_objects`) 
 
 ## Naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ then, you MUST move to [First-party](#first-party).
 
 - Spell variable names out in full using American English spelling (e.g. `optimized_pulse` or `optimizedPulse` and **NOT** `op`)
 - For variable names that are more than three words, use an acronym (e.g. `cpmg` and **NOT** `carr_purcell_meiboom_gill` or `carrPurcellMeiboomGill`)
-- For variable names that describe how many of an object there are, use `<object>_count` (e.g. `pulse_count`, not `number_of_pulses` or `pulses_count`)
+- For variable names that describe how many of an object there are, use `<object>_count` or `<object>Count` (e.g. `pulse_count` or `pulseCount` and **NOT** `number_of_pulses`, `numberOfPulses`, `pulses_count` or `pulsesCount`)
 
 ## Naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ then, you MUST move to [First-party](#first-party).
 
 - Spell variable names out in full using American English spelling (e.g. `optimized_pulse` or `optimizedPulse` and **NOT** `op`)
 - For variable names that are more than three words, use an acronym (e.g. `cpmg` and **NOT** `carr_purcell_meiboom_gill` or `carrPurcellMeiboomGill`)
-- For variable names that describe how many of an object there are, use `<object>_count` (not `<object>s_count`, not `number_of_objects`) 
+- For variable names that describe how many of an object there are, use `<object>_count` (e.g. `pulse_count`, not `number_of_pulses` or `pulses_count`)
 
 ## Naming conventions
 


### PR DESCRIPTION
This is somewhat arbitrary, but at least defines something, and seems to have some decent advantages:
 - stackoverflow agrees (https://stackoverflow.com/questions/3742650/naming-conventions-for-number-of-foos-variables)
 - naturally supports the case where `<object>` is plural (e.g. if we need to know how many lists of `foo` objects there should be, we can use `foos_count`)