### PR TITLE
Describe numpydoc++

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
   <contents>
   """
   ```
-- Use single backticks when referring to a module, function, class, method, parameter, variable or attribute thereof; otherwise use double backticks (e.g. `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` ` or ` ``List[int]`` `)
+- Use single backticks when referring to a module, function, class, method, parameter, variable or attribute thereof; otherwise use double backticks (for example `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` ` or ` ``List[int]`` `).
 
 ## Naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,11 @@ then, you MUST move to [First-party](#first-party).
 
 The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard is unopinionated and/or inconsistent in a small number of cases. We therefore adopt the following additional standards:
 
-- Place the leading triple quote of each docstring on its own line
+- Place the leading and final triple quotes of each docstring on their own lines, with no blank lines separating them from the contents, as follows:
+  ```
+  """
+  <contents>
+  """
 - Use single backticks when referring to a module, function, class, method, parameter, variable or attribute thereof; otherwise use double backticks (e.g. `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` ` or ` ``List[int]`` `)
 
 ## Naming conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ then, you MUST move to [First-party](#first-party).
 
 | Third-party | Style                                                                                                          | Docstrings                                                        | Testing                       | Linting                           |
 |-------------|----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|-------------------------------|-----------------------------------|
-| Django      | [Django coding style](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/) | [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) | [pytest](https://pytest.org/) | [Pylint](https://www.pylint.org/) |
+| Django      | [Django coding style](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/) | [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)[[++](#numpydoc-docstrings)] | [pytest](https://pytest.org/) | [Pylint](https://www.pylint.org/) |
 | React       | [Prettier](https://prettier.io/)                                                                               | [JSDoc](http://usejsdoc.org/)                                     | [Jest](https://jestjs.io/)    | [ESLint](https://eslint.org/)     |
 
 ## Language standards
@@ -136,7 +136,7 @@ then, you MUST move to [First-party](#first-party).
 | HTML       | [Prettier](https://prettier.io/)                   | N/A                                                               | [HTMLProofer](https://github.com/gjtorikian/html-proofer/) | N/A                                                                        |
 | JavaScript | [Prettier](https://prettier.io/)                   | [JSDoc](http://usejsdoc.org/)                                     | [Jest](https://jestjs.io/)                                 | [ESLint](https://eslint.org/)                                              |
 | Markdown   | [Prettier](https://prettier.io/)                   | N/A                                                               | N/A                                                        | [Markdownlint](https://github.com/markdownlint/markdownlint/)              |
-| Python     | [PEP 8](https://www.python.org/dev/peps/pep-0008/) | [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) | [pytest](https://pytest.org/)                              | [Pylint](https://www.pylint.org/)                                          |
+| Python     | [PEP 8](https://www.python.org/dev/peps/pep-0008/) | [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)[[++](#numpydoc-docstrings)] | [pytest](https://pytest.org/)                              | [Pylint](https://www.pylint.org/)                                          |
 
 ## Q-CTRL coding standards
 
@@ -145,6 +145,13 @@ then, you MUST move to [First-party](#first-party).
 - Spell variable names out in full using American English spelling (e.g. `optimized_pulse` or `optimizedPulse` and **NOT** `op`)
 - For variable names that are more than three words, use an acronym (e.g. `cpmg` and **NOT** `carr_purcell_meiboom_gill` or `carrPurcellMeiboomGill`)
 - For variable names that describe how many of an object there are, use `<object>_count` or `<object>Count` (e.g. `pulse_count` or `pulseCount` and **NOT** `number_of_pulses`, `numberOfPulses`, `pulses_count` or `pulsesCount`)
+
+### numpydoc docstrings
+
+The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard is unopinionated and/or inconsistent in a small number of cases. We therefore adopt the following addition standards:
+
+- Place the leading triple quote of each docstring on its own line
+- Use single backticks when referring to a module, function, class, method, parameter, variable or attribute thereof; otherwise use double backticks (e.g. `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` ` or ` ``List[int]`` `)
 
 ## Naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
   """
   <contents>
   """
+  ```
 - Use single backticks when referring to a module, function, class, method, parameter, variable or attribute thereof; otherwise use double backticks (e.g. `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` ` or ` ``List[int]`` `)
 
 ## Naming conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
   <contents>
   """
   ```
-- Use single backticks when referring to a module, function, class, method, parameter, variable or attribute thereof; otherwise use double backticks (for example `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` ` or ` ``List[int]`` `).
+- Use single backticks when referring to a module, function, class, method, parameter, variable, or attribute thereof; otherwise use double backticks (for example `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` `, or ` ``List[int]`` `).
 
 ## Naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ then, you MUST move to [First-party](#first-party).
 
 ### numpydoc docstrings
 
-The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard is unopinionated and/or inconsistent in a small number of cases. We therefore adopt the following addition standards:
+The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard is unopinionated and/or inconsistent in a small number of cases. We therefore adopt the following additional standards:
 
 - Place the leading triple quote of each docstring on its own line
 - Use single backticks when referring to a module, function, class, method, parameter, variable or attribute thereof; otherwise use double backticks (e.g. `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` ` or ` ``List[int]`` `)


### PR DESCRIPTION
numpydoc isn't prescriptive (or consistent) about whether leading/trailing `"""`s should be on their own lines, or whether they should be separated from the contents by blank lines, so we just pick a configuration (on their own lines, with no blank lines, for aesthetics)

numpydoc also isn't clear (or consistent) about when to use single backticks and when to use double backticks. It says ["Variable, module, function, and class names should be written between single back-ticks"](https://numpydoc.readthedocs.io/en/latest/format.html#common-rest-concepts), but then also [uses double backticks for built-in types in an example](https://github.com/numpy/numpydoc/blob/master/doc/example.py#L52) (which is surprising because built-in types are also classes). We therefore define a specific list of cases where single backticks should be used. This list is based on the general idea that "identifiers" should use single backticks and "expressions" should use double backticks (this is only a general idea because the distinction between identifiers and expressions is somewhat meaningless in Python, but is still hopefully quite intuitive), which seems consistent with the spirit of what numpydoc is aiming for.