### PR TITLE
Updates language standards to include specification for GraphQL documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ When contributing code, bear in mind that Q-CTRL values the [Three Virtues](http
 
 | Language   | Style                                              | Docstrings                                                        | Testing                                                    | Linting                                                                    |
 |------------|----------------------------------------------------|-------------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------|
-| GraphQL    | [GraphQL Rules](https://graphql-rules.com/)        | N/A                                                               | N/A                                                        | [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) |
+| GraphQL    | [GraphQL Rules](https://graphql-rules.com/)        | [CommonMark](https://commonmark.org/)[[++](#GraphQL-docstrings)] | N/A                                                        | [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) |
 | HTML       | [Prettier](https://prettier.io/)                   | N/A                                                               | [HTMLProofer](https://github.com/gjtorikian/html-proofer/) | N/A                                                                        |
 | JavaScript | [Prettier](https://prettier.io/)                   | [JSDoc](http://usejsdoc.org/)                                     | [Jest](https://jestjs.io/)                                 | [ESLint](https://eslint.org/)                                              |
 | Markdown   | [Prettier](https://prettier.io/)                   | N/A                                                               | N/A                                                        | [Markdownlint](https://github.com/markdownlint/markdownlint/)              |
@@ -161,6 +161,27 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
   """
   ```
 - Use single backticks when referring to a module, function, class, method, parameter, variable, or attribute thereof; otherwise use double backticks (for example `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` `, or ` ``List[int]`` `).
+
+### GraphQL Docstrings
+
+In most cases we try and follow the Markdown syntax as specified by [CommonMark](http://commonmark.org/) which is the standard for  GraphQL docstrings. Unfortunately the CommonMark specification does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. We therefore have these additional custom specifications in place:
+
+- Inline math needs to start with ``$` and end with a matching `$``:
+```
+`$$`
+```
+
+- Math blocks are similair to code blocks, but require the language be set to "math":
+```
+ ```math
+ ```
+```
+
+- Footnote referencing should use the following syntax instead of the CommonMark syntax:
+
+For more information and examples on how we use GraphQL docstrings for documenting core features and functions, follow the [link](https://github.com/qctrl/api2#writing-documentation-for-core-features-in-the-graphql-api) to the relevant section in the api2 documentation.
+
+
 
 ### Citations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
 
 ### GraphQL Docstrings
 
-In most cases we try and follow the Markdown syntax as specified by [CommonMark](http://commonmark.org/) which is the standard adopted and recommended by GraphQL. Unfortunately the CommonMark specification does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. We therefore have these additional custom specifications in place:
+In most cases the [CommonMark](http://commonmark.org/) standard reccomended by GrapqhQL is followed. Unfortunately the specification is not comprehensive and does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. In these special cases there are additional custom specifications in place that extend the specification provided by CommonMark:
 
 - Inline math needs to start with `` `$ `` and end with `` $` ``:
 ```
@@ -184,10 +184,6 @@ This is my sentence with a footnote[^1].
 
 [^1]: My reference.
 ```
-
-For more information and examples on how we use GraphQL docstrings for documenting core features and functions in the api, follow the [link](https://github.com/qctrl/api2#writing-documentation-for-core-features-in-the-graphql-api) to the relevant section in the api2 documentation.
-
-
 
 ### Citations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ In most cases we try and follow the Markdown syntax as specified by [CommonMark]
 `$E=mc^2$`
 ```
 
-- Math blocks are similair to code blocks, but require the language be set to "math":
+- Math blocks are similair to code blocks, but require the language be set to `math`:
 ````
  ```math
  E=mc^2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
 
 ### GraphQL Docstrings
 
-In most cases we try and follow the Markdown syntax as specified by [CommonMark](http://commonmark.org/) which is the standard adopted and reccomended by GraphQL . Unfortunately the CommonMark specification does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. We therefore have these additional custom specifications in place:
+In most cases we try and follow the Markdown syntax as specified by [CommonMark](http://commonmark.org/) which is the standard adopted and recommended by GraphQL. Unfortunately the CommonMark specification does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. We therefore have these additional custom specifications in place:
 
 - Inline math needs to start with `` `$ `` and end with `` $` ``:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
 
 In most cases we try and follow the Markdown syntax as specified by [CommonMark](http://commonmark.org/) which is the standard adopted and reccomended by GraphQL . Unfortunately the CommonMark specification does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. We therefore have these additional custom specifications in place:
 
-- ``Inline math needs to start with "`$" and end with a matching "$`" `` :
+- Inline math needs to start with `` `$ `` and end with `` $` ``:
 ```
 `$E=mc^2$`
 ```
@@ -185,7 +185,7 @@ This is my sentence with a footnote[^1].
 [^1]: My reference.
 ```
 
-For more information and examples on how we use GraphQL docstrings for documenting core features and functions, follow the [link](https://github.com/qctrl/api2#writing-documentation-for-core-features-in-the-graphql-api) to the relevant section in the api2 documentation.
+For more information and examples on how we use GraphQL docstrings for documenting core features and functions in the api, follow the [link](https://github.com/qctrl/api2#writing-documentation-for-core-features-in-the-graphql-api) to the relevant section in the api2 documentation.
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
 
 ### GraphQL Docstrings
 
-In most cases the [CommonMark](http://commonmark.org/) standard recommended by GrapqhQL is followed. Unfortunately the specification is not comprehensive and does not cover all use cases, as the docstrings to document client-side functions and not just the API. In these special cases there are additional custom specifications in place that extend the specification provided by CommonMark:
+In most cases the [CommonMark](http://commonmark.org/) standard recommended by GrapqhQL is followed. Unfortunately the specification is not comprehensive and does not cover all use cases, as the docstrings can be used to document client-side functions and not just the API. In these special cases there are additional custom specifications in place that extend the specification provided by CommonMark:
 
 - Inline math needs to start with `` `$ `` and end with `` $` ``:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
 
 ### GraphQL Docstrings
 
-In most cases the [CommonMark](http://commonmark.org/) standard reccomended by GrapqhQL is followed. Unfortunately the specification is not comprehensive and does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. In these special cases there are additional custom specifications in place that extend the specification provided by CommonMark:
+In most cases the [CommonMark](http://commonmark.org/) standard recommended by GrapqhQL is followed. Unfortunately the specification is not comprehensive and does not cover all use cases, as the docstrings to document client-side functions and not just the API. In these special cases there are additional custom specifications in place that extend the specification provided by CommonMark:
 
 - Inline math needs to start with `` `$ `` and end with `` $` ``:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ In most cases we try and follow the Markdown syntax as specified by [CommonMark]
 `$E=mc^2$`
 ```
 
-- Math blocks are similair to code blocks, but require the language be set to `math`:
+- Math blocks are similar to code blocks, but require the language to be set to `math`:
 ````
  ```math
  E=mc^2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,20 +164,26 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
 
 ### GraphQL Docstrings
 
-In most cases we try and follow the Markdown syntax as specified by [CommonMark](http://commonmark.org/) which is the standard for  GraphQL docstrings. Unfortunately the CommonMark specification does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. We therefore have these additional custom specifications in place:
+In most cases we try and follow the Markdown syntax as specified by [CommonMark](http://commonmark.org/) which is the standard adopted and reccomended by GraphQL . Unfortunately the CommonMark specification does not cover all of our use cases, as we use the docstrings to document our client-side functions and not just the API. We therefore have these additional custom specifications in place:
 
-- Inline math needs to start with ``$` and end with a matching `$``:
+- ``Inline math needs to start with "`$" and end with a matching "$`" `` :
 ```
-`$$`
+`$E=mc^2$`
 ```
 
 - Math blocks are similair to code blocks, but require the language be set to "math":
-```
+````
  ```math
+ E=mc^2
  ```
-```
+````
 
 - Footnote referencing should use the following syntax instead of the CommonMark syntax:
+```
+This is my sentence with a footnote[^1].
+
+[^1]: My reference.
+```
 
 For more information and examples on how we use GraphQL docstrings for documenting core features and functions, follow the [link](https://github.com/qctrl/api2#writing-documentation-for-core-features-in-the-graphql-api) to the relevant section in the api2 documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ When contributing code, bear in mind that Q-CTRL values the [Three Virtues](http
 | Language   | Style                                                    | Docstrings                                                        | Testing                                                    | Linting                                                                    |
 |------------|----------------------------------------------------------|-------------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------|
 | Go         | [Effective Go](https://golang.org/doc/effective_go.html) | [Godoc](https://blog.golang.org/godoc)                            | [go test](https://golang.org/pkg/testing/)                 | [Golint](https://github.com/golang/lint)                                   |
-| GraphQL    | [GraphQL Rules](https://graphql-rules.com/)              | [CommonMark](https://commonmark.org/)[[++](#GraphQL-docstrings)] | N/A                                                        | [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) |
+| GraphQL    | [GraphQL Rules](https://graphql-rules.com/)              | [CommonMark](https://commonmark.org/)[[++](#graphql-docstrings)] | N/A                                                        | [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) |
 | HTML       | [Prettier](https://prettier.io/)                         | N/A                                                               | [HTMLProofer](https://github.com/gjtorikian/html-proofer/) | N/A                                                                        |
 | JavaScript | [Prettier](https://prettier.io/)                         | [JSDoc](http://usejsdoc.org/)                                     | [Jest](https://jestjs.io/)                                 | [ESLint](https://eslint.org/)                                              |
 | Markdown   | [Prettier](https://prettier.io/)                         | N/A                                                               | N/A                                                        | [Markdownlint](https://github.com/markdownlint/markdownlint/)              |
@@ -163,7 +163,7 @@ The [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) standard i
   ```
 - Use single backticks when referring to a module, function, class, method, parameter, variable, or attribute thereof; otherwise use double backticks (for example `` `np.array` ``, `` `int` ``, `` `parameter_1` ``, `` `CustomClass.attribute` ``, `` `CustomClass.method` ``, ` ``value_1*value_2`` `, ` ``function().result`` `, or ` ``List[int]`` `).
 
-### GraphQL Docstrings
+### GraphQL docstrings
 
 In most cases the [CommonMark](http://commonmark.org/) standard recommended by GrapqhQL is followed. Unfortunately the specification is not comprehensive and does not cover all use cases, as the docstrings can be used to document client-side functions and not just the API. In these special cases there are additional custom specifications in place that extend the specification provided by CommonMark:
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Specifies CommonMark as the standard for GraphQL documentation.
- Adds information about the additional syntax used on top of the CommonMark syntax.
