### PR TITLE
Add guidelines for Python naming with acronyms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,7 @@ Unless prescribed otherwise by the framework or language (as described above), u
 - Spell variable names out in full using American English spelling (for example `optimized_pulse` or `optimizedPulse` and **NOT** `op`).
 - For variable names that are more than three words, use an acronym (for example `cpmg` and **NOT** `carr_purcell_meiboom_gill` or `carrPurcellMeiboomGill`).
 - For variable names that describe how many of an object there are, use `<object>_count` or `<object>Count` (for example `pulse_count` or `pulseCount` and **NOT** `number_of_pulses`, `numberOfPulses`, `pulses_count`, or `pulsesCount`).
+- Capitalize only the first letter of acronyms in camelCase or PascalCase names (for example `QctrlApiException` or `tensorPwc` and **NOT** `QCTRLAPIException` or `tensorPWC`).
 
 #### Docstrings
 


### PR DESCRIPTION
This is in slight disagreement with PEP8 (https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles), but:
 - PEP8 explicitly states that, despite its guidelines, there’s always going to be inconsistency
 - we’re already not following this part of PEP8 quite widely
 - things like `QCTRLAPIException` look ridiculous

Will work on a lint check for this too.

Proposed this on Slack and didn't hear any objections.