### PR TITLE
feat: Add Jira link stub to PR template for related issue/ticket

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Addresses: (link to issue/ticket)
+Addresses: https://q-ctrl.atlassian.net/browse/(ticket)
 
 Changes proposed in this pull request:
 


### PR DESCRIPTION

Adds a Jira link stub to the Pull Request template to conveniently paste the related issue/ticket.

(I will investigate a bit further if we can automate this a bit better.)