### PR TITLE
misc: Add release.yml configuration file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - misc
+    authors:
+      - qctrl-devops
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking
+    - title: What's new
+      labels:
+        - feat
+    - title: Bug fixes
+      labels:
+        - fix
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Following the suggestion made in [this comment](https://docs.google.com/document/d/1E58yp2moNh8cYyTtgKzXvn4L6gJJqgrmfkx7n5wnok8/edit?disco=AAAATtVUDJQ) , this pull request adds a `.github/release.yml` file to this repo, as a way of testing whether this configuration file applies to the automatic generation of release notes in all the repos.

Changes proposed in this pull request:

- Add a `.github/release.yml` file.