### PR TITLE
feat: Clarify reverting commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,22 +47,22 @@ Note that:
 
 - We prefer squash merges from short-lived branches (for example `feature/ABC-123`) to long-lived branches (for example `master`).
 - If you're a member of the Q-CTRL team, you're responsible for merging your own pull requests once reviewed and approved.
-- The following table (extracted from [commitlint](https://github.com/conventional-changelog/commitlint/blob/c936401be64dfc82b2efb69e4e17060f4c9cc3a3/%40commitlint/config-conventional/index.js#L39) ) is a guide on how to choose a proper type for your pull requests/commit messages.
+- The following table (whose two left columns are extracted from [commitlint](https://github.com/conventional-changelog/commitlint/blob/c936401be64dfc82b2efb69e4e17060f4c9cc3a3/%40commitlint/config-conventional/index.js#L39) ) is a guide on how to choose a proper type for your pull requests/commit messages. The two columns on the right provide guidance on the type of release a commit triggers (major has precedence over minor, which has precendence over patch), and which section of the release notes each change should go in.
 
 ### Supported pull request types
 
-| Type       | Purpose                                                                                                    |
-| ---------- | ---------------------------------------------------------------------------------------------------------- |
-| `feat`     | A new feature                                                                                              |
-| `fix`      | A bug fix                                                                                                  |
-| `perf`     | A code change that improves performance                                                                    |
-| `refactor` | A code change that neither fixes a bug nor adds a feature                                                  |
-| `chore`    | Other changes that don't modify src or test files                                                          |
-| `revert`   | Reverts a previous commit                                                                                  |
-| `build`    | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)        |
-| `ci`       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)|
-| `docs`     | Documentation only changes                                                                                 |
-| `style`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)     |
-| `test`     | Adding missing tests or correcting existing tests                                                          |
+| Type       | Purpose                                                                                                    | Type of release | Release notes section |
+| ---------- | ---------------------------------------------------------------------------------------------------------- | --------------- | -------------------------- |
+| `feat`     | A new feature                                                                                              | Minor           | What's new                 |
+| `fix`      | A bug fix                                                                                                  | Patch           | Bug fixes                  |
+| `perf`     | A code change that improves performance                                                                    | Patch           | What's new                 |
+| `refactor` | A code change that neither fixes a bug nor adds a feature                                                  | Patch           | What's new                 |
+| `chore`    | Other changes that don't modify src or test files                                                          | Patch           | What's new                 |
+| `revert`   | Reverts a previous commit                                                                                  | Patch           | Bug fixes                  |
+| `build`    | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)        | Patch           | What's new                 |
+| `ci`       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)| Patch           | What's new                 |
+| `docs`     | Documentation only changes                                                                                 | Patch           | don't add to release notes |
+| `style`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)     | Patch           | don't add to release notes |
+| `test`     | Adding missing tests or correcting existing tests                                                          | Patch           | don't add to release notes |
 
 More information [about pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,22 +47,22 @@ Note that:
 
 - We prefer squash merges from short-lived branches (for example `feature/ABC-123`) to long-lived branches (for example `master`).
 - If you're a member of the Q-CTRL team, you're responsible for merging your own pull requests once reviewed and approved.
-- The following table (whose two left columns are extracted from [commitlint](https://github.com/conventional-changelog/commitlint/blob/c936401be64dfc82b2efb69e4e17060f4c9cc3a3/%40commitlint/config-conventional/index.js#L39) ) is a guide on how to choose a proper type for your pull requests/commit messages. The two columns on the right provide guidance on the type of release a commit triggers (major has precedence over minor, which has precendence over patch), and which section of the release notes each change should go in.
+- The following table (whose two left columns are extracted from [commitlint](https://github.com/conventional-changelog/commitlint/blob/c936401be64dfc82b2efb69e4e17060f4c9cc3a3/%40commitlint/config-conventional/index.js#L39) ) is a guide on how to choose a proper type for your pull requests/commit messages. The two columns on the right provide guidance on the type of release a commit triggers (major has precedence over minor, which has precendence over patch), and which [section of the release notes](https://code.q-ctrl.com/releases#description) each change should go in.
 
 ### Supported pull request types
 
-| Type       | Purpose                                                                                                    | Type of release | Release notes section |
-| ---------- | ---------------------------------------------------------------------------------------------------------- | --------------- | -------------------------- |
-| `feat`     | A new feature                                                                                              | Minor           | What's new                 |
-| `fix`      | A bug fix                                                                                                  | Patch           | Bug fixes                  |
-| `perf`     | A code change that improves performance                                                                    | Patch           | What's new                 |
-| `refactor` | A code change that neither fixes a bug nor adds a feature                                                  | Patch           | What's new                 |
-| `chore`    | Other changes that don't modify src or test files                                                          | Patch           | What's new                 |
-| `revert`   | Reverts a previous commit                                                                                  | Patch           | Bug fixes                  |
-| `build`    | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)        | Patch           | What's new                 |
-| `ci`       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)| Patch           | What's new                 |
-| `docs`     | Documentation only changes                                                                                 | Patch           | don't add to release notes |
-| `style`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)     | Patch           | don't add to release notes |
-| `test`     | Adding missing tests or correcting existing tests                                                          | Patch           | don't add to release notes |
+| Type       | Purpose                                                                                                    | Type of release | Release notes section        |
+| ---------- | ---------------------------------------------------------------------------------------------------------- | --------------- | ---------------------------- |
+| `feat`     | A new feature                                                                                              | Minor           | What's new                   |
+| `fix`      | A bug fix                                                                                                  | Patch           | Bug fixes                    |
+| `perf`     | A code change that improves performance                                                                    | Patch           | What's new                   |
+| `refactor` | A code change that neither fixes a bug nor adds a feature                                                  | Patch           | What's new                   |
+| `chore`    | Other changes that don't modify src or test files                                                          | Patch           | What's new                   |
+| `revert`   | Reverts a previous commit                                                                                  | Patch           | Bug fixes                    |
+| `build`    | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)        | Patch           | What's new                   |
+| `ci`       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)| Patch           | What's new                   |
+| `docs`     | Documentation only changes                                                                                 | Patch           | (don't add to release notes) |
+| `style`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)     | Patch           | (don't add to release notes) |
+| `test`     | Adding missing tests or correcting existing tests                                                          | Patch           | (don't add to release notes) |
 
 More information [about pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,14 +53,14 @@ Note that:
 
 | Type       | Purpose                                                                                                    | Type of release | Release notes section        |
 | ---------- | ---------------------------------------------------------------------------------------------------------- | --------------- | ---------------------------- |
-| `feat`     | A new feature                                                                                              | Minor           | What's new                   |
+| `feat`     | A new feature                                                                                              | Minor           | New features                 |
 | `fix`      | A bug fix                                                                                                  | Patch           | Bug fixes                    |
-| `perf`     | A code change that improves performance                                                                    | Patch           | What's new                   |
-| `refactor` | A code change that neither fixes a bug nor adds a feature                                                  | Patch           | What's new                   |
-| `chore`    | Other changes that don't modify src or test files                                                          | Patch           | What's new                   |
-| `revert`   | Reverts a previous commit                                                                                  | Patch           | Bug fixes                    |
-| `build`    | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)        | Patch           | What's new                   |
-| `ci`       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)| Patch           | What's new                   |
+| `perf`     | A code change that improves performance                                                                    | Patch           | Improvements                 |
+| `refactor` | A code change that neither fixes a bug nor adds a feature                                                  | Patch           | (don't add to release notes) |
+| `chore`    | Other changes that don't modify src or test files                                                          | Patch           | (don't add to release notes) |
+| `revert`   | Reverts a previous commit                                                                                  | Patch           | Improvements                 |
+| `build`    | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)        | Patch           | Improvements                 |
+| `ci`       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)| Patch           | (don't add to release notes) |
 | `docs`     | Documentation only changes                                                                                 | Patch           | (don't add to release notes) |
 | `style`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)     | Patch           | (don't add to release notes) |
 | `test`     | Adding missing tests or correcting existing tests                                                          | Patch           | (don't add to release notes) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,11 @@ Note that:
 | `style`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)     | Patch           | (don't add to release notes) |
 | `test`     | Adding missing tests or correcting existing tests                                                          | Patch           | (don't add to release notes) |
 
-For `revert` commits, the release notes section in which it is included depends on the type of reverted commit and whether it has been released. 
+For `revert` commits, the type of release it leads to and the release notes section in which it is included depend on both the type of the reverted commit and whether it has been released.
 If the reverted commit hasn't been released yet (that is, it would be in the same release notes as the `revert` commit), then neither of the commits should be advertised in the release notes.
 Note that this might change the type of release, for instance, if the reverted commit was the only new feature or only breaking change in the release.
 If the reverted commit has already been included in a previous release, then the reverting commit should be classified on its own merit depending on its changes. 
-For example, if the reverted commit added a feature, the reverting commit would be a breaking change (leading to a new major release);
+For example, if the reverted commit added a feature, the reverting commit would be a breaking change (leading to a major release);
 if the reverted commit removed a feature, the reverting commit would be adding a new feature (leading to a minor release);
 and if the reverted commit wasn't advertised in its release notes, then the reverting commit shouldn't be advertised either.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,19 @@ Note that:
 | `perf`     | A code change that improves performance                                                                    | Patch           | Improvements                 |
 | `refactor` | A code change that neither fixes a bug nor adds a feature                                                  | Patch           | (don't add to release notes) |
 | `chore`    | Other changes that don't modify src or test files                                                          | Patch           | (don't add to release notes) |
-| `revert`   | Reverts a previous commit                                                                                  | Patch           | Improvements                 |
+| `revert`   | Reverts a previous commit                                                                                  | (depends)       | (depends, see below)         |
 | `build`    | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)        | Patch           | Improvements                 |
 | `ci`       | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)| Patch           | (don't add to release notes) |
 | `docs`     | Documentation only changes                                                                                 | Patch           | (don't add to release notes) |
 | `style`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)     | Patch           | (don't add to release notes) |
 | `test`     | Adding missing tests or correcting existing tests                                                          | Patch           | (don't add to release notes) |
+
+For `revert` commits, the release notes section in which it is included depends on the type of reverted commit and whether it has been released. 
+If the reverted commit hasn't been released yet (that is, it would be in the same release notes as the `revert` commit), then neither of the commits should be advertised in the release notes.
+Note that this might change the type of release, for instance, if the reverted commit was the only new feature or only breaking change in the release.
+If the reverted commit has already been included in a previous release, then the reverting commit should be classified on its own merit depending on its changes. 
+For example, if the reverted commit added a feature, the reverting commit would be a breaking change (leading to a new major release);
+if the reverted commit removed a feature, the reverting commit would be adding a new feature (leading to a minor release);
+and if the reverted commit wasn't advertised in its release notes, then the reverting commit shouldn't be advertised either.
 
 More information [about pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).


### PR DESCRIPTION
I've tried to add some clarification on `revert` commits. Please let me know if this makes any sense to do, and whether the text is clear.