### PR TITLE
chore: Update code of conduct and contributing links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: Contributing
-    url: https://github.com/qctrl/.github/blob/master/CONTRIBUTING.md
+    url: https://code.q-ctrl.com/contributing
     about: Guidelines for contributing to Q-CTRL projects.
   - name: Code of Conduct
-    url: https://github.com/qctrl/.github/blob/master/CODE_OF_CONDUCT.md
+    url: https://code.q-ctrl.com/code-of-conduct
     about: Code of conduct for contributing to Q-CTRL projects.
   - name: Security
     url: https://github.com/qctrl/.github/blob/master/SECURITY.md

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 Community health files for the [@qctrl](https://github.com/qctrl) organization.
 
-- [Code of conduct](https://github.com/qctrl/.github/blob/master/CODE_OF_CONDUCT.md)
+- [Code of conduct](https://code.q-ctrl.com/code-of-conduct)
 - [Contributing](https://code.q-ctrl.com/contributing)
 - [Security](https://github.com/qctrl/.github/blob/master/SECURITY.md)
 - [Support](https://github.com/qctrl/.github/blob/master/SUPPORT.md)


### PR DESCRIPTION
Changes proposed in this pull request:

- Update links for our [code of conduct](https://code.q-ctrl.com/code-of-conduct) and [contributing](https://code.q-ctrl.com/contributing) documents in the README and issue template configuration.
